### PR TITLE
chore: Update version in sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ jobs:
     - name: build release
       run: ./gradlew assembleRelease
     - name: upload artefact to App Center
-      uses: wzieba/AppCenter-Github-Action@v1.0.1
+      uses: wzieba/AppCenter-Github-Action@v1.1.1
       with:
         appName: wzieba/Sample-App
         token: ${{secrets.APP_CENTER_TOKEN}}


### PR DESCRIPTION
In next iteration I'll move to use separate branch for major version releases (described here https://help.github.com/en/actions/creating-actions/about-actions#using-tags-for-release-management) so we won't have to specify exact version.