### PR TITLE
Add notifyTesters option

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,8 @@ COPY . /app
 
 RUN npm install -g appcenter-cli@2.5.4 \
     && apk update \
-    && apk add git 
+    && apk add git \
+    && apk add bash
 
 RUN chmod +x /app/entrypoint.sh
 

--- a/README.md
+++ b/README.md
@@ -27,11 +27,13 @@ This action uploads artefacts (.apk or .ipa) to Visual Studio App Center.
 
 Release notes visible on release page
 
-
 ### `gitReleaseNotes`
 
 Generate release notes based on the latest git commit
 
+### `notifyTesters`
+
+If set to true, an email notification is sent to the distribution group
 
 ## Example usage
 
@@ -60,4 +62,5 @@ jobs:
         token: ${{secrets.APP_CENTER_TOKEN}}
         group: Testers
         file: app/build/outputs/apk/release/app-release-unsigned.apk
+        notifyTesters: true
 ```

--- a/action.yml
+++ b/action.yml
@@ -1,28 +1,31 @@
-name: 'App Center'
-description: 'GitHub Action that uploads artefacts for Visual Studio App Center'
-author: 'Wojciech Zięba <@wzieba>'
+name: "App Center"
+description: "GitHub Action that uploads artefacts for Visual Studio App Center"
+author: "Wojciech Zięba <@wzieba>"
 inputs:
   appName:
-    description: 'App name followed by username e.g. wzieba/Sample-App'
+    description: "App name followed by username e.g. wzieba/Sample-App"
     required: true
   token:
-    description: 'Upload token - you can get one from appcenter.ms/settings'
+    description: "Upload token - you can get one from appcenter.ms/settings"
     required: true
   group:
-    description: 'Distribution group'
+    description: "Distribution group"
     required: true
   file:
-    description: 'Artefact to upload (.apk or .ipa)'
+    description: "Artefact to upload (.apk or .ipa)"
     required: true
   releaseNotes:
-    description: 'Release notes visible on release page'
+    description: "Release notes visible on release page"
     required: false
   gitReleaseNotes:
     description: "Generate release notes based on the latest git commit"
     required: false
+  notifyTesters:
+    description: "If true, send an email notification to the distribution group"
+    required: false
 branding:
-  color: 'red' 
-  icon: 'send'
+  color: "red"
+  icon: "send"
 runs:
-  using: 'docker'
-  image: 'Dockerfile'
+  using: "docker"
+  image: "Dockerfile"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,6 +3,8 @@ RELEASE_NOTES=""
 isFirst=true
 releaseId=""
 export IFS=";"
+params=()
+[ "${INPUT_NOTIFYTESTERS}" != true ] && params+=(--silent)
 if [ -n "${INPUT_RELEASENOTES}" ]; then
     RELEASE_NOTES=${INPUT_RELEASENOTES}
 elif [ $INPUT_GITRELEASENOTES ]; then
@@ -11,9 +13,9 @@ fi
 for group in $INPUT_GROUP; do
     if ${isFirst} ; then
         isFirst=false
-        appcenter distribute release --token "$INPUT_TOKEN" --app "$INPUT_APPNAME" --group $group --file "$INPUT_FILE" --release-notes "$INPUT_RELEASENOTES" --silent
+        appcenter distribute release --token "$INPUT_TOKEN" --app "$INPUT_APPNAME" --group $group --file "$INPUT_FILE" --release-notes "$INPUT_RELEASENOTES" "${params[@]}"
         releaseId=$(appcenter distribute releases list --token "$INPUT_TOKEN"  --app "$INPUT_APPNAME" | grep ID | head -1 | tr -s ' ' | cut -f2 -d ' ')
     else
-        appcenter distribute releases add-destination --token "$INPUT_TOKEN" -d $group -t group -r $releaseId -s --app "$INPUT_APPNAME"
+        appcenter distribute releases add-destination --token "$INPUT_TOKEN" -d $group -t group -r $releaseId --app "$INPUT_APPNAME" "${params[@]}"
     fi
 done

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -14,7 +14,7 @@ for group in $INPUT_GROUP; do
     if ${isFirst} ; then
         isFirst=false
         appcenter distribute release --token "$INPUT_TOKEN" --app "$INPUT_APPNAME" --group $group --file "$INPUT_FILE" --release-notes "$INPUT_RELEASENOTES" "${params[@]}"
-        releaseId=$(appcenter distribute releases list --token "$INPUT_TOKEN"  --app "$INPUT_APPNAME" | grep ID | head -1 | tr -s ' ' | cut -f2 -d ' ')
+        releaseId=$(appcenter distribute releases list --token "$INPUT_TOKEN"  --app "$INPUT_APPNAME" | grep ID | tr -s ' ' | cut -f2 -d ' ' | sort --numeric-sort --reverse | head -1)
     else
         appcenter distribute releases add-destination --token "$INPUT_TOKEN" -d $group -t group -r $releaseId --app "$INPUT_APPNAME" "${params[@]}"
     fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 RELEASE_NOTES=""
 isFirst=true
 releaseId=""

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -14,7 +14,7 @@ for group in $INPUT_GROUP; do
     if ${isFirst} ; then
         isFirst=false
         appcenter distribute release --token "$INPUT_TOKEN" --app "$INPUT_APPNAME" --group $group --file "$INPUT_FILE" --release-notes "$INPUT_RELEASENOTES" "${params[@]}"
-        releaseId=$(appcenter distribute releases list --token "$INPUT_TOKEN"  --app "$INPUT_APPNAME" | grep ID | tr -s ' ' | cut -f2 -d ' ' | sort --numeric-sort --reverse | head -1)
+        releaseId=$(appcenter distribute releases list --token "$INPUT_TOKEN"  --app "$INPUT_APPNAME" | grep ID | tr -s ' ' | cut -f2 -d ' ' | sort -n -r | head -1)
     else
         appcenter distribute releases add-destination --token "$INPUT_TOKEN" -d $group -t group -r $releaseId --app "$INPUT_APPNAME" "${params[@]}"
     fi


### PR DESCRIPTION
This pull request adds a notifyTesters option. This will conditionally add the "--silent" flag to the appcenter distribute command. If the option is set to true, the flag is omitted and notifications will be sent. If the flag is other than true (or not present), the flag is added and no notifications are sent.

Also improved the script command to determine the release number. The list needs to be sorted to ensure that the latest release number is used.

The script modification requires bash, so bash was added to the dockerfile.