### PR TITLE
Add support for the build-version and build-number arguments

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,12 @@ inputs:
   file:
     description: "Artefact to upload (.apk or .ipa)"
     required: true
+  buildVersion:
+    description: "Build version parameter required for .zip, .msi, .pkg and .dmg files"
+    required: false
+  buildNumber:
+    description: "Build number parameter required for macOS .pkg and .dmg files"
+    required: false
   releaseNotes:
     description: "Release notes visible on release page"
     required: false

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,6 +11,15 @@ if [ -n "${INPUT_RELEASENOTES}" ]; then
 elif [ $INPUT_GITRELEASENOTES ]; then
     RELEASE_NOTES="$(git log -1 --pretty=short)"
 fi
+
+if [ -n "${INPUT_BUILDVERSION}" ]; then
+    params+=(--build-version "$INPUT_BUILDVERSION")
+fi
+
+if [ -n "${INPUT_BUILDNUMBER}" ]; then
+    params+=(--build-number "$INPUT_BUILDNUMBER")
+fi
+
 for group in $INPUT_GROUP; do
     if ${isFirst} ; then
         isFirst=false


### PR DESCRIPTION
This PR proposes adding support for the `build-version` and `build-number` arguments to the CLI tool. These are often required for macOS-based projects. 