### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ This action uploads artifacts (.apk or .ipa) to Visual Studio App Center.
 ### `buildVersion`
   Build version parameter required for .zip, .msi, .pkg and .dmg files"
 
+### buildNumber
+  "Build number parameter required for macOS .pkg and .dmg files"
+
 ### `releaseNotes`
 
 Release notes visible on release page

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This action uploads artifacts (.apk or .ipa) to Visual Studio App Center.
 **Required** Artifact to upload (.apk or .ipa)
 
 ### `buildVersion`
-  Build version parameter required for .zip, .msi, .pkg and .dmg files"
+Build version parameter required for .zip, .msi, .pkg and .dmg files
 
 ### buildNumber
   "Build number parameter required for macOS .pkg and .dmg files"
@@ -80,4 +80,3 @@ jobs:
         notifyTesters: true
         debug: false
 ```
-

--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ This action uploads artifacts (.apk or .ipa) to Visual Studio App Center.
 
 **Required** Artifact to upload (.apk or .ipa)
 
+### `buildVersion`
+  Build version parameter required for .zip, .msi, .pkg and .dmg files"
+
 ### `releaseNotes`
 
 Release notes visible on release page

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This action uploads artifacts (.apk or .ipa) to Visual Studio App Center.
 Build version parameter required for .zip, .msi, .pkg and .dmg files
 
 ### buildNumber
-  "Build number parameter required for macOS .pkg and .dmg files"
+Build number parameter required for macOS .pkg and .dmg files
 
 ### `releaseNotes`
 


### PR DESCRIPTION
I noticed that support for buildVersion and buildNumber was adder recently but the docs are not updated. ([Add support for the build-version and build-number arguments](#27))

I would really need a release with these changes since I need to deliver zip files, no pressure, but is there any planned date for it?