### PR TITLE
Upgrade appcenter-cli version to 2.7.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM node:12.10.0-alpine
 WORKDIR /app
 COPY . /app
 
-RUN npm install -g appcenter-cli@2.5.4 \
+RUN npm install -g appcenter-cli@2.7.3 \
     && apk update \
     && apk add git \
     && apk add bash


### PR DESCRIPTION
Description of the problem:
---------
Error `500` appears when trying to download apk to AppCenter.

Proposed solution:
----------
In technical support, I was advised to update the appcenter-cli version to version `2.7.0+.`

Changes:
----------
`appcenter-cli` version has been updated to `2.7.3`