### PR TITLE
Support AppCenter Download URL as environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,11 @@ This action uploads artifacts (.apk or .ipa) to Visual Studio App Center.
 **Required** Artifact to upload (.apk or .ipa)
 
 ### `buildVersion`
+
 Build version parameter required for .zip, .msi, .pkg and .dmg files
 
 ### buildNumber
+
 Build number parameter required for macOS .pkg and .dmg files
 
 ### `releaseNotes`
@@ -49,6 +51,14 @@ If set to true, shows useful debug information from the action execution.
 
 This action is Docker-based. It means **it can only execute on runners with a Linux operating system**.
 See Github Actions [documentation](https://docs.github.com/en/actions/creating-actions/about-actions#docker-container-actions) for details.
+
+## Supported Evnvironment Variables
+
+This action support environment variables for convenience. ([setting-an-environment-variable](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-environment-variable))
+
+| Env Var                   | Description                        |
+| ------------------------- | ---------------------------------- |
+| `APPCENTER_DOWNLOAD_LINK` | URL to download Artifact uploaded. |
 
 ## Sample usage
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -29,6 +29,9 @@ for group in $INPUT_GROUP; do
         isFirst=false
         appcenter distribute release --token "$INPUT_TOKEN" --app "$INPUT_APPNAME" --group $group --file "$INPUT_FILE" --release-notes "$RELEASE_NOTES" "${params[@]}"
         releaseId=$(appcenter distribute releases list --token "$INPUT_TOKEN"  --app "$INPUT_APPNAME" | grep ID | tr -s ' ' | cut -f2 -d ' ' | sort -n -r | head -1)
+        downloadUrl=$(appcenter distribute releases show --token "$INPUT_TOKEN"  --app "$INPUT_APPNAME" --release-id "$releaseId" --output json | grep -o '"[^"]*"\s*:\s*"[^"]*"' | grep -E '^"downloadUrl"' | cut  -d ':' -f 2,3 | tr -d '"')
+        
+        echo "APPCENTER_DOWNLOAD_LINK=$downloadUrl" >> "$GITHUB_ENV"
     else
         appcenter distribute releases add-destination --token "$INPUT_TOKEN" -d $group -t group -r $releaseId --app "$INPUT_APPNAME" "${params[@]}"
     fi


### PR DESCRIPTION
* There is a demand to utilize the `AppCenter download Url` , so add logic to support it.